### PR TITLE
Permite indicar en la configuracion directorio

### DIFF
--- a/src/Config.java
+++ b/src/Config.java
@@ -60,6 +60,7 @@ public class Config {
 	 */
 	private static void postProcessConfig() {
 		createDirAtHome();
+		searchAndBuildFilesPath();
 		normalizeVariableContent("UrbanoSHPPath");
 		normalizeVariableContent("RusticoSHPPath");
 		try {
@@ -81,6 +82,45 @@ public class Config {
 			);
 		}
 		configureGrid();
+	}
+	/**
+	 * Si se indica un directorio como parametro InputDirPath, busca en el
+	 * los archivos cat.gz y SHF.zip necesarios, y completa la configuración.
+	 * Ojo, el directorio solo debe contener los archivos de un municipio/localidad
+	 * 
+	 */
+	private static void searchAndBuildFilesPath(){
+		// Si no esta definida ignoramos.
+		if ("".equals(configuration.getProperty("InputDirPath", ""))){
+			return;
+		}
+		// Si se han indicado los archivos por separado ignoramos.
+		if (!"".equals(configuration.getProperty("UrbanosSHPPath", ""))){
+			return;
+		}
+		File directorio = new File(configuration.getProperty("InputDirPath"));
+		if (!directorio.exists()){
+			return;
+		}
+		File[] entradas = directorio.listFiles();
+		for (File fichero:entradas){
+			if (fichero.isFile()){
+				String nombre = fichero.getName().toUpperCase();
+				if (nombre.matches("^\\d+_\\d+_RA_\\d+-\\d+-\\d+_SHF\\.ZIP$")){
+					configuration.setProperty("RusticoSHPPath", fichero.getAbsolutePath());
+					
+				}
+				else if (nombre.matches("^\\d+_\\d+_UA_\\d+-\\d+-\\d+_SHF\\.ZIP$")){
+					configuration.setProperty("UrbanoSHPPath", fichero.getAbsolutePath());
+				}
+				else if (nombre.matches("^\\d+_\\d+_U_\\d+-\\d+-\\d+\\.CAT\\.GZ$")){
+					configuration.setProperty("UrbanoCATFile", fichero.getAbsolutePath());
+				}
+				else if (nombre.matches("^\\d+_\\d+_R_\\d+\\-\\d+\\-\\d+\\.CAT\\.GZ$")){
+					configuration.setProperty("RusticoCATFile", fichero.getAbsolutePath());
+				}
+			}
+		}
 	}
 	/** 
 	 * Crea un directorio para catosm (".catosm") en el directorio del usuario.


### PR DESCRIPTION
Se indica en el archivo de configuracion el directorio donde se encuentran los archivos de catastro a procesar, mediante la clave InputDirPath.

cat2osm busca en ese directorio los 4 archivos de catastro necesarios y termina de hacer la configuración con ellos.

Nota: El directorio debe contener solo los archivos de catastro de un municipio, tal y cual se descargan de la web de catastro, es decir, no hay que renombrarlos ni descomprimirlos.
