### PR TITLE
Corregido borrado de datos de la parcela si no tiene entrada

### DIFF
--- a/src/Cat2Osm.java
+++ b/src/Cat2Osm.java
@@ -771,10 +771,11 @@ public class Cat2Osm {
 						entrance.getAttributes().addAttribute("addr:street", shape.getAttributes().getValue("addr:street"));
 						entrance.getAttributes().addAttribute("addr:postcode", shape.getAttributes().getValue("addr:postcode"));
 					}
+					// Y borramos esos tags de la parcela sólo en este caso, si la parcela
+                                        // no tiene entradas los dejamos igual^M
+					shape.getAttributes().removeAttribute("addr:street");
+					shape.getAttributes().removeAttribute("addr:postcode");
 				}
-				// Y borramos esos tags de la parcela
-				shape.getAttributes().removeAttribute("addr:street");
-				shape.getAttributes().removeAttribute("addr:postcode");
 				
 			} else 
 				// Si encontramos una MASA RUSTICA 


### PR DESCRIPTION
Hola
En la versión actual si una parcela no tiene entradas definidas pierde todos los datos de dirección asociados. 
He corregido esto aunque puede tener problemas estúpidos de carácteres debido al editor de linux vs windows y porque tampoco he podido compilarlo. Wishlist, ¿un makefile o similar? 
